### PR TITLE
Fix tests global

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# find boost unittest package
+find_package(Boost COMPONENTS unit_test_framework REQUIRED)
+
+# find qt6 package
+#find_package(Qt6 REQUIRED COMPONENTS Core Test)
+
+# add subdirs
+add_subdirectory(eval)
+add_subdirectory(integration)
+add_subdirectory(unit)
+add_subdirectory(performance)
+

--- a/test/eval/CMakeLists.txt
+++ b/test/eval/CMakeLists.txt
@@ -1,0 +1,17 @@
+# project settings
+aux_source_directory(. SRC_LIST_TEST_BOOST_PYTHON)
+
+# find boost::python
+find_package(Boost 1.74 REQUIRED COMPONENTS system python)
+
+# set binary executable
+add_executable(test-boost-python test-boost-python.cpp)
+
+# set include
+target_include_directories(test-boost-python PRIVATE ${Python3_INCLUDE_DIRS})
+
+# set target link flags
+target_link_libraries(test-boost-python ${PYTHON_LIBRARIES})
+target_link_libraries(test-boost-python ${Boost_LIBRARIES})
+
+#target_link_libraries(test-staticfs-thread-processing ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -1,0 +1,5 @@
+# add subdirs
+add_subdirectory(event)
+add_subdirectory(boost-regex)
+add_subdirectory(string-functions)
+add_subdirectory(vector-multi-erase)

--- a/test/integration/boost-regex/CMakeLists.txt
+++ b/test/integration/boost-regex/CMakeLists.txt
@@ -1,0 +1,10 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_BOOST_REGEX)
+
+# find boost unittest package
+find_package(Boost COMPONENTS regex REQUIRED)
+
+add_executable(test-boost-regex "test-boost-regex.cpp")
+
+target_link_libraries(test-boost-regex ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_link_libraries(test-boost-regex ${Boost_LIBRARIES})

--- a/test/integration/event/CMakeLists.txt
+++ b/test/integration/event/CMakeLists.txt
@@ -1,0 +1,17 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_INTEGRATION_EVENT)
+
+# add binary
+add_executable(test-event "test-Event.cpp" "TestClass.cpp")
+
+# add custom targets
+add_custom_target(
+    TestEventHeader
+    SOURCES
+    ./TestClass.hpp
+    ../../../lib/event/Event.hpp
+)
+
+# link libraries
+target_link_libraries(test-event ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+target_link_libraries(test-event libevent2)

--- a/test/integration/string-functions/CMakeLists.txt
+++ b/test/integration/string-functions/CMakeLists.txt
@@ -1,0 +1,6 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_STRING_FUNCTIONS)
+
+add_executable(test-string-functions "test-string-functions.cpp")
+
+target_link_libraries(test-string-functions ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/test/integration/vector-multi-erase/CMakeLists.txt
+++ b/test/integration/vector-multi-erase/CMakeLists.txt
@@ -1,0 +1,6 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_INTEGRATION_VECTOR_MULTI_ERASE)
+
+add_executable(test-Vector-multi-erase "test-Vector-multi-erase.cpp")
+
+target_link_libraries(test-Vector-multi-erase ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/test/performance/CMakeLists.txt
+++ b/test/performance/CMakeLists.txt
@@ -1,0 +1,8 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_PERFORMANCE)
+
+# add binary
+add_executable(test-performance ${SRC_LIST_TEST_PERFORMANCE})
+
+# link libraries
+target_link_libraries(test-performance ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,2 @@
+# add source dir
+aux_source_directory(. SRC_LIST_TEST_UNIT)


### PR DESCRIPTION
A wrong line in .gitignore prevented CMakeLists.txt files needed for building. Fixed now.