### PR TITLE
Add Debug Build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -46,15 +46,29 @@ Details (e.g. building module) see [XML Parser Documentation](https://github.com
 
 ## 1.4. Compile / Install
 
+On installation "testapp1.local" and "testapp2.local" with address 127.0.0.1 will
+be added to ```/etc/hosts```.
+
 ```bash
 # compile / install
-cmake CMakeLists.txt
+cmake CMakeLists.txt .
 make
 make install
 ```
 
-On installation "testapp1.local" and "testapp2.local" with address 127.0.0.1 will
-be added to ```/etc/hosts```.
+```bash
+# debug build
+cmake -DDEBUG_BUILD=1 CMakeLists.txt .
+make
+make install
+```
+
+```bash
+# java backend build
+cmake -DJAVA_BACKEND=1 CMakeLists.txt .
+make
+make install
+```
 
 ## 1.5. Start Server
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -65,6 +65,7 @@ make install
 
 ```bash
 # java backend build
+export JAVA_HOME=/usr/lib/jvm/jdk-24.0.2-oracle-x64/
 cmake -DJAVA_BACKEND=1 CMakeLists.txt .
 make
 make install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 cmake_minimum_required(VERSION 3.11)
 project(falcon-as)
 
-# do not print out warning
-set(ignoreMe "${JAVA_BACKEND}")
+# do not print out warnings about unused variables
+set(ignoreMe "${JAVA_BACKEND} ${DEBUG_BUILD}")
 
 # find python3
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
@@ -36,8 +36,12 @@ if ( DEFINED JAVA_BACKEND )
 endif()
 
 # set g++ compiler flags
-set(CMAKE_CXX_FLAGS "-I/usr/include/python3.10 -I/usr/include/python3.10 -g -fPIC -Wall -pthread -O2 -fstack-protector-strong -std=c++20 -Wno-unused-result -Wsign-compare -Wformat -Werror=format-security -DNDEBUG -fwrapv")
-#set(CMAKE_CXX_FLAGS "-I/usr/include/python3.10 -I/usr/include/python3.10 -g -fPIC -Wall -pthread -fstack-protector-strong -std=c++20 -Wno-unused-result -Wsign-compare -Wformat -Werror=format-security -fwrapv")
+if ( DEFINED DEBUG_BUILD )
+    add_compile_definitions(DEBUG_BUILD)
+    set(CMAKE_CXX_FLAGS "-g -fPIC -Wall -pthread -std=c++20 -Wno-unused-result -Wsign-compare -Wformat -Werror=format-security -fwrapv -rdynamic")
+else()
+    set(CMAKE_CXX_FLAGS "-g -fPIC -Wall -pthread -O3 -fstack-protector-strong -std=c++20 -Wno-unused-result -Wsign-compare -Wformat -Werror=format-security -DNDEBUG -fwrapv")
+endif()
 
 # set boost specs
 set(Boost_USE_STATIC_LIBS OFF)
@@ -49,6 +53,7 @@ add_executable(${PROJECT_NAME} ${SRC_LIST})
 
 # java or python backend
 if ( DEFINED JAVA_BACKEND )
+    add_compile_definitions(JAVA_BACKEND)
     add_custom_target(
         JavaBackendHeaderFiles
         SOURCES

--- a/src/ASProcessHandler.cpp
+++ b/src/ASProcessHandler.cpp
@@ -79,6 +79,11 @@ void ASProcessHandler::forkProcessASHandler(ASProcessHandlerSHMPointer_t SHMAdre
 
                 DBG(20, "ASIndex:" << Index << " Process UID:" << getuid() << " GID:" << getgid());
 
+                #if defined(DEBUG_BUILD)
+                //- overwrite termination handler (display backtrace)
+                std::set_terminate(SigHandler::myterminate);
+                #endif
+
                 /*
                 //- set process name
                 std::string ProcessNameDyn = "falcon-as-python" + std::to_string(Index);
@@ -138,10 +143,12 @@ void ASProcessHandler::forkProcessASHandler(ASProcessHandlerSHMPointer_t SHMAdre
                         new(getMetaAddress(Index, 0)) uint16_t(0);
                         new(getMetaAddress(Index, 1)) uint16_t(1);
                     }
+                    else {
+                        this_thread::sleep_for(chrono::microseconds(IDLE_SLEEP_MICROSECONDS));
+                        //this_thread::sleep_for(chrono::seconds(1));
+                        DBG(300, "Process PythonAS idle.");
+                    }
 
-                    this_thread::sleep_for(chrono::microseconds(IDLE_SLEEP_MICROSECONDS));
-                    //this_thread::sleep_for(chrono::seconds(1));
-                    DBG(300, "Process PythonAS alive:");
                 }
 
                 DBG(-1, "Exit Parent ASProcessHandler Process.");

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -32,6 +32,11 @@ void Server::init()
     //- disable OS signals SIGINT, SIGPIPE
     Signal::disableSignals();
 
+    #if defined(DEBUG_BUILD)
+    //- overwrite termination handler (display backtrace)
+    std::set_terminate(SigHandler::myterminate);
+    #endif
+
     //- setup termination handler
     setTerminationHandler();
 


### PR DESCRIPTION
# Pull Request

## Description

Add debug build `cmake -DDEBUG_BUILD=1 .`. If set to 1, process termination on c++ exception prints out backtrace / stacktrace for better debugging (in server main process and all forked application server processes).

Also correct CMakeLists.txt to correctly set preprocessor vars for **Debug** and **JavaAS** build.

## Type of Change

- [x] New feature
