### PR TITLE
Replace Python Config Processing

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,56 @@
+{
+    "namespaces":
+    [
+        {
+            "id": "app1",
+            "hostname": "testapp1.local",
+            "path": "/app1",
+            "interpreters": 5
+        },
+        {
+            "id": "app2",
+            "hostname": "testapp2.local",
+            "path": "/app2",
+            "interpreters": 3
+        }
+    ],
+    "global":
+    {
+        "path":
+        {
+            "base": "/var/www"
+        },
+        "tcp":
+        {
+            "cork": false,
+            "nodelay": true
+        }
+    },
+    "server":
+    {
+        "runas":
+        {
+            "user": "x0-http",
+            "group": "x0-http"
+        },
+        "connection":
+        {
+            "timeout": "600",
+            "ipv4":
+            {
+                "address": "127.0.0.1",
+                "port": 80
+            }
+        },
+        "mimetypes":
+            [
+                "html", "js", "json", "css", "png", "jpg", "svg", "woff2"
+            ]
+    },
+    "cpu-binding":
+    {
+        "main-server": [ 0 ],
+        "staticfs": [ 1 ],
+        "app-server": [ 2, 3 ]
+    }
+}

--- a/config/config.json
+++ b/config/config.json
@@ -35,7 +35,7 @@
         },
         "connection":
         {
-            "timeout": "600",
+            "timeout": 600,
             "ipv4":
             {
                 "address": "127.0.0.1",

--- a/scripts/cp_etc.sh
+++ b/scripts/cp_etc.sh
@@ -3,7 +3,6 @@
 mkdir -p /etc/falcon-http
 chown falcon-http:falcon-http /etc/falcon-http
 chmod 750 /etc/falcon-http
-cp ./python/config.py /etc/falcon-http/
-cp ./python/config.xml /etc/falcon-http/
+cp ./config/config.json /etc/falcon-http/
 chmod 550 /etc/falcon-http/*
 chown -R falcon-http:falcon-http /etc/falcon-http/*

--- a/src/ASProcessHandler.hpp
+++ b/src/ASProcessHandler.hpp
@@ -21,6 +21,12 @@
 #include "Configuration.hpp"
 #include "ASRequestHandler.hpp"
 
+#define PY_SSIZE_T_CLEAN
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+
+#include <boost/python.hpp>
+#include <Python.h>
+
 #if defined(JAVA_BACKEND)
 #include <jni.h>
 #endif

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -47,8 +47,6 @@ Configuration::Configuration() :
             );
         }
     }
-    catch( const char* msg )
-    {
     catch( const nlohmann::json::exception& e )
     {
         ERR("Config file parse error:" << e.what());

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -12,6 +12,10 @@ Configuration::Configuration() :
 
     try {
         ifstream ConfigFile(CONFIG_FILE);
+        if (!ConfigFile.is_open()) {
+            ERR("Could not open config file: " << CONFIG_FILE);
+            exit(1);
+        }
         json jsonData = json::parse(ConfigFile);
 
         RunAsUnixUser = jsonData["server"]["runas"]["user"];

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -45,7 +45,9 @@ Configuration::Configuration() :
     }
     catch( const char* msg )
     {
-        ERR("Config file parse error:" << msg);
+    catch( const nlohmann::json::exception& e )
+    {
+        ERR("Config file parse error:" << e.what());
         exit(1);
     }
 }

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -11,7 +11,7 @@ Configuration::Configuration() :
     DBG(120, "Constructor");
 
     try {
-        ifstream ConfigFile(CONFIG_FILE);
+        std::ifstream ConfigFile(CONFIG_FILE);
         if (!ConfigFile.is_open()) {
             ERR("Could not open config file: " << CONFIG_FILE);
             exit(1);

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -1,17 +1,11 @@
 #ifndef Configuration_hpp
 #define Configuration_hpp
 
-#define BOOST_BIND_GLOBAL_PLACEHOLDERS
-
-#include <boost/python.hpp>
-#include <boost/python/dict.hpp>
-
-#define PY_SSIZE_T_CLEAN
-
-#include <Python.h>
-
+#include <fstream>
 #include <string>
 #include <ctime>
+
+#include <nlohmann/json.hpp>
 
 #include "Debug.cpp"
 

--- a/src/Constant.hpp
+++ b/src/Constant.hpp
@@ -6,7 +6,7 @@
 
 #define LOG_LEVEL 251
 
-#define SERVER_VERSION "v0.1beta"
+#define SERVER_VERSION "v0.1"
 
 #define CLIENTS_MAX 4096*2
 #define NET_BACKLOG CLIENTS_MAX
@@ -15,7 +15,7 @@
 
 #define EPOLL_FD_COUNT_MAX 256
 
-#define IDLE_SLEEP_MICROSECONDS 1000
+#define IDLE_SLEEP_MICROSECONDS 500
 
 #define HTTP_REQUEST_MAX_SIZE 4096
 #define HTTP_RESPONSE_MAX_SIZE 4096*2
@@ -25,4 +25,5 @@
 #define STATICFS_SUBDIR "/static"
 #define BACKEND_ROOT_PATH "/backend"
 
+#define CONFIG_FILE "/etc/falcon-http/config.json"
 #endif


### PR DESCRIPTION
# Pull Request

## Description

Configuration processing with Python `python-micro-xmlparser` adds unneccesary non c++ dependencies.
Switch to native c++ by using this library https://github.com/nlohmann/json.

- Details #117

## Related Issue

- Closes #117

## Type of Change

- [x] New feature
- [x] Refactor
