### PR TITLE
Convert from c+17 to c++11 syntax (arduino port)

### DIFF
--- a/lib/http/httpparser.hpp
+++ b/lib/http/httpparser.hpp
@@ -144,8 +144,8 @@ public:
         JSONPayload = "{ \"payload\": {";
 
         uint16_t i = 0;
-        for (const auto& [ParamName, ParamValue]: URLParamsMap) {
-            JSONPayload += " \"" + ParamName + "\": \"" + ParamValue + "\"";
+        for (const auto& ParamPair: URLParamsMap) {
+            JSONPayload += " \"" + ParamPair.first + "\": \"" + ParamPair.second + "\"";
             if (i != URLParamsMap.size()-1) {
                 JSONPayload += ",";
             }


### PR DESCRIPTION
# Pull Request

## Description

Arduino port must compile with C++11 syntax, C++17 syntax used.
