### PR TITLE
Fix External Header Include - Release Candidate V0.2

### DIFF
--- a/lib/http/httpparser.cpp
+++ b/lib/http/httpparser.cpp
@@ -1,4 +1,5 @@
 #include "httpparser.hpp"
+#include "httpconstants.hpp"
 
 using namespace std;
 

--- a/lib/http/httpparser.hpp
+++ b/lib/http/httpparser.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include <stdint.h>
-
 #include <string>
 #include <vector>
 #include <memory>
+#include <cstdint>
 #include <utility>
 #include <algorithm>
 #include <unordered_map>

--- a/lib/http/httpparser.hpp
+++ b/lib/http/httpparser.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #include <string>
 #include <vector>
 #include <memory>

--- a/lib/http/httpparser.hpp
+++ b/lib/http/httpparser.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "httpconstants.hpp"
-
 #include <string>
 #include <vector>
 #include <memory>

--- a/test/unit/http-parser/test-parser-requests.cpp
+++ b/test/unit/http-parser/test-parser-requests.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE( test_single_valid_get_request_full_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 1);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_GET);
     BOOST_TEST(ru == "/test/test.png");
     BOOST_TEST(rh == "one");
 
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE( test_single_post_request_full_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << " Payload: " << rp << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 2);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_POST);
     BOOST_TEST(ru == "/backend/test1");
     BOOST_TEST(rh == "test.loalnet");
     BOOST_TEST(rp == "{}");
@@ -213,8 +213,8 @@ BOOST_AUTO_TEST_CASE( test_single_valid_post_request_partial_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 2);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_POST);
     BOOST_TEST(ru == "/other/path");
     BOOST_TEST(rh == "application/json");
 
@@ -244,8 +244,8 @@ BOOST_AUTO_TEST_CASE( test_single_valid_get_request_1byte_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 1);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_GET);
     BOOST_TEST(ru == "/test/test.png");
     BOOST_TEST(rh == "one");
 }
@@ -275,8 +275,8 @@ BOOST_AUTO_TEST_CASE( test_single_post_request_1byte_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << " Payload: " << rp << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 2);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_POST);
     BOOST_TEST(ru == "/backend/test1");
     BOOST_TEST(rh == "test.loalnet");
     BOOST_TEST(rp == "{}");
@@ -427,8 +427,8 @@ BOOST_AUTO_TEST_CASE( test_single_valid_post_request_partial_1byte_transmit )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 2);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_POST);
     BOOST_TEST(ru == "/other/path");
     BOOST_TEST(rh == "application/json");
 }
@@ -455,8 +455,8 @@ BOOST_AUTO_TEST_CASE( test_valid_get_parameters_1 )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 1);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_GET);
     BOOST_TEST(ru == "/test/test.html?a=1&b=2");
     BOOST_TEST(rh == "three");
     BOOST_TEST(rg1 == "1");
@@ -487,8 +487,8 @@ BOOST_AUTO_TEST_CASE( test_valid_get_parameters_2 )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 1);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_GET);
     BOOST_TEST(ru == "/test2.html?hello=hello1&test=test2&here=there");
     BOOST_TEST(rh == "two");
     BOOST_TEST(rg1 == "hello1");
@@ -520,8 +520,8 @@ BOOST_AUTO_TEST_CASE( test_urlparamsmap2_json )
     cout << "Request size: " << rs << " version: " << rv << " method: " << rm << " URL: " << ru << " Header: " << rh << endl;
 
     BOOST_TEST(rs == 1);
-    BOOST_TEST(rv == 1);
-    BOOST_TEST(rm == 1);
+    BOOST_TEST(rv == HTTP_VERSION_1_1);
+    BOOST_TEST(rm == HTTP_METHOD_GET);
     BOOST_TEST(ru == "/test2.html?hello=hello1&test=test2&here=there");
     BOOST_TEST(rh == "two");
     BOOST_TEST(rg1 == "hello1");

--- a/test/unit/http-parser/test-parser-requests.cpp
+++ b/test/unit/http-parser/test-parser-requests.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../../../lib/http/httpparser.hpp"
+#include "../../../lib/http/httpconstants.hpp"
 
 using namespace std;
 


### PR DESCRIPTION
# Pull Request

## Problem

Including `httpconstants.hpp` in `httpparser.hpp` caused a compilation error when using the installed c++ header files from `/usr/local/include` path after `make install`for the following libraries:

- Linux x86_64 httpparser library in `/lib/http/`
- Arduino ESP32-C3 port in `/ports/arduino/esp32c3/`

## Solution

Include `httpconstants.hpp` in `httpparser.cpp`, **not** `httpparser.hpp`.

## Related Issue

Fixes #187.

## Type of Change

- [x] Bug fix

## Remark

This PR will also introduce Version `v0.2` which **only** includes a stable HTTP/1.1 parser library for x86_64 and the Arduino ESP32-C3 port.

